### PR TITLE
Feature/allow filtering of patches

### DIFF
--- a/commands/patchset.py
+++ b/commands/patchset.py
@@ -45,28 +45,28 @@ logger = logging.getLogger(__name__)
     '--all_patchsets', '-a', is_flag=True, required=False,
     type=click.BOOL, default=False, help='If set, all full patchsets are created.')
 @click.option(
-    '--filter_include', '-i',
+    '--filters_include', '-i',
     type=click.STRING,
     multiple=True,
     required=False,
     help='''The patch is only included if at least one of the tags defined here is present here that are configured for the patch.''')
 @click.option(
-    '--filter_exclude', '-e',
+    '--filters_exclude', '-e',
     type=click.STRING,
     multiple=True,
     required=False,
     help='''The patch is NOT included if one or more tags are present here that are configured for the patch.''')
 @click.argument('outpath', type=click.Path())
 @click.pass_context
-def patchset(ctx, layer, patchdir, outpath, all_patchsets, filter_include, filter_exclude):
+def patchset(ctx, layer, patchdir, outpath, all_patchsets, filters_include, filters_exclude):
     '''Create a patchset for a given layer. If "all" is selected: for each full
     path through the tree (e.g. for each leaf) creates a full patchset.'''
     need_layer_config(ctx)
     if all_patchsets:
-        create_all_sets(ctx, patchdir, outpath, filter_include, filter_exclude)
+        create_all_sets(ctx, patchdir, outpath, filters_include, filters_exclude)
     else:
         if layer:
-            _patchset_internal(ctx, layer, patchdir, outpath, filter_include, filter_exclude)
+            _patchset_internal(ctx, layer, patchdir, outpath, filters_include, filters_exclude)
         else:
             exit_with_error("You need to specify either a layer using -l or -a for all layers.")
 
@@ -303,7 +303,7 @@ def get_all_referred_layers(layer, tree):
         node = tree.parent(node.identifier)
     return reversed(layers)
 
-def create_all_sets(ctx, patchdir, outpath, filter_include, filter_exclude):
+def create_all_sets(ctx, patchdir, outpath, filters_include, filters_exclude):
     """For each full path through the tree
     (e.g. for each leaf) creates a full patchset"""
 
@@ -315,12 +315,12 @@ def create_all_sets(ctx, patchdir, outpath, filter_include, filter_exclude):
         logger.info("Creating patchset for leaf %s", leaf.identifier)
         _patchset_internal(ctx, leaf.identifier, patchdir,
                            os.path.join(outpath, leaf.identifier),
-                           filter_include, filter_exclude)
+                           filters_include, filters_exclude)
         logger.info("Done!")
     logger.info("Created %d full patchsets", len(tree.leaves()))
 
 
-def create_patchset(ctx, layer, filter_include, filter_exclude):
+def create_patchset(ctx, layer, filters_include, filters_exclude):
     '''Creates a patchset for the selected layer'''
     tree = ctx.obj['LAYER_TREE']
 
@@ -340,34 +340,27 @@ def create_patchset(ctx, layer, filter_include, filter_exclude):
             current_layer = referred_layer.id
         # if no filter is defined: just add all patches:
         #logger.info(referred_layer.patches)
-        if len(filter_exclude) == 0 and len(filter_include) == 0:
+        if len(filters_exclude) == 0 and len(filters_include) == 0:
             patch_set.patches.extend(referred_layer.patches)
         else:
             # else: we check every patch it if fits the include/exclude pattern
             # first: include, then: exclude
             for patch in referred_layer.patches:
                 tags = []
-                logger.info(patch.tags)
                 if patch.tags is not None:
-                    logger.info(tags)
                     tags = [i.strip() for i in patch.tags.split(',')]
-                #logger.info(tags)
                 exclude = False
                 include = True
                 # check for include/exclude filter before appending:
-                if len(filter_include) > 0:
-                    #logger.info("Checking for include filters: %s", ','.join(filter_include))
+                if len(filters_include) > 0:
                     include = False
                     if not include:
-                        for filter in filter_include:
-                            #logger.info(filter)
-                            #logger.info(patch.tags)
-                            if filter in tags:
+                        for include_filter in filters_include:
+                            if include_filter in tags:
                                 include = True
-                if len(filter_exclude) > 0:
-                    #logger.info("Checking for exclude filters: %s", ','.join(filter_exclude))
-                    for filter in filter_exclude:
-                        if filter in tags:
+                if len(filters_exclude) > 0:
+                    for exclude_filter in filters_exclude:
+                        if exclude_filter in tags:
                             exclude = True
                 if not exclude and include:
                     logger.info("Including patch %s!", patch)
@@ -379,12 +372,12 @@ def create_patchset(ctx, layer, filter_include, filter_exclude):
 
     return patch_set
 
-def _patchset_internal(ctx, layer, patchdir, outpath, filter_include, filter_exclude):
+def _patchset_internal(ctx, layer, patchdir, outpath, filters_include, filters_exclude):
     '''Create a patchset for a given layer.'''
     if os.path.exists(outpath):
         exit_with_error("Outpath may not exist: " + outpath)
 
-    patch_set = create_patchset(ctx, layer, filter_include, filter_exclude)
+    patch_set = create_patchset(ctx, layer, filters_include, filters_exclude)
     # write patch info file to our folder...
     logger.info("Creating output folder %s", outpath)
     os.makedirs(outpath)

--- a/configuration/data.py
+++ b/configuration/data.py
@@ -17,6 +17,7 @@ class PatchConfig():
     """Contains one patch for a given subdir/path"""
     basePath: str
     patch: str
+    tags: str
     updateModulesAfterPatch: bool = False
     # This is a way to include a baseline entry into a PatchConfig to apply.
     # There might be a more "python" way to do this though...
@@ -33,6 +34,10 @@ class PatchConfig():
     def is_patch(self) -> bool:
         '''True if a patch is defined'''
         return len(self.patch) > 0
+
+    def has_tags(self) -> bool:
+        '''True if at least one filter is defined'''
+        return len(self.tags) > 0
 
 @dataclass_json
 @dataclass

--- a/configuration/data.py
+++ b/configuration/data.py
@@ -17,7 +17,7 @@ class PatchConfig():
     """Contains one patch for a given subdir/path"""
     basePath: str
     patch: str
-    tags: str
+    tags: str = ""
     updateModulesAfterPatch: bool = False
     # This is a way to include a baseline entry into a PatchConfig to apply.
     # There might be a more "python" way to do this though...

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ dataclasses_json==0.5.7
 GitPython==3.1.30
 Jinja2==3.0.3
 md2pdf==1.0.1
-pip==22.0.2
 PyDriller==2.4.1
 setuptools==59.6.0
 treelib==1.6.1

--- a/tuxlayers.py
+++ b/tuxlayers.py
@@ -93,7 +93,6 @@ def parse_tree_from_layers(ctx):
             layers[layer_id] = layer_config
 
     layer_tree = treelib.Tree()
-    logger.info(layer_tree)
     if base_layer is None:
         return layer_tree
     layer_tree.create_node(base_layer.id, base_layer.id, data=base_layer)
@@ -119,16 +118,11 @@ def load_layer_config(config_folder, layer_filename):
         exit_with_error("Could not find " + layer_file)
 
     with open(layer_file, encoding='UTF-8') as json_content:
-        logger.info(layer_file)
         # Further file processing goes here
         data_json = json_content.read()
         try:
             # pylint: disable=no-member
             data_layer = PatchLayer.from_json(data_json)
-            logger.info("lasdalsijd")
-            logger.info(data_layer)
-            logger.info("lasdalsijd")
-
             return data_layer
         except ValueError as value_error:
             exit_with_error(value_error)

--- a/tuxlayers.py
+++ b/tuxlayers.py
@@ -93,6 +93,7 @@ def parse_tree_from_layers(ctx):
             layers[layer_id] = layer_config
 
     layer_tree = treelib.Tree()
+    logger.info(layer_tree)
     if base_layer is None:
         return layer_tree
     layer_tree.create_node(base_layer.id, base_layer.id, data=base_layer)
@@ -118,11 +119,16 @@ def load_layer_config(config_folder, layer_filename):
         exit_with_error("Could not find " + layer_file)
 
     with open(layer_file, encoding='UTF-8') as json_content:
+        logger.info(layer_file)
         # Further file processing goes here
         data_json = json_content.read()
         try:
             # pylint: disable=no-member
             data_layer = PatchLayer.from_json(data_json)
+            logger.info("lasdalsijd")
+            logger.info(data_layer)
+            logger.info("lasdalsijd")
+
             return data_layer
         except ValueError as value_error:
             exit_with_error(value_error)


### PR DESCRIPTION
Allowing to add a "tags" field (comma-seperated list) for each configured patch. If a value is in there, we can filter (include & exclude) patches for a specific tag. Include and exclude can be combined.